### PR TITLE
Fix sabadell xls

### DIFF
--- a/changelog/+acbb0ceb.bugfix.md
+++ b/changelog/+acbb0ceb.bugfix.md
@@ -1,0 +1,1 @@
+Fix XLS files in Sabadell when pending transactions where present. Sabadell can also now identify file type automatically.

--- a/src/ynab_unlinked/entities/sabadell/command.py
+++ b/src/ynab_unlinked/entities/sabadell/command.py
@@ -5,8 +5,6 @@ from typing import Annotated
 
 import typer
 
-from .constants import InputType
-
 
 def command(
     context: typer.Context,

--- a/src/ynab_unlinked/entities/sabadell/command.py
+++ b/src/ynab_unlinked/entities/sabadell/command.py
@@ -14,12 +14,6 @@ def command(
         Path,
         typer.Argument(exists=True, file_okay=True, dir_okay=False, readable=True),
     ],
-    input_type: Annotated[
-        InputType,
-        typer.Option(
-            "-t", "--input-type", show_choices=True, help="The type of the file to be parsed"
-        ),
-    ] = InputType.TXT,
 ):
     """
     Inputs transactions from a Sabadell TXT or XLS file.
@@ -36,7 +30,7 @@ def command(
     ctx: YnabUnlinkedContext = context.obj
 
     process_transactions(
-        entity=SabadellParser(input_type),
+        entity=SabadellParser(),
         input_file=input_file,
         context=ctx,
     )

--- a/src/ynab_unlinked/entities/sabadell/constants.py
+++ b/src/ynab_unlinked/entities/sabadell/constants.py
@@ -1,6 +1,0 @@
-from enum import Enum
-
-
-class InputType(Enum):
-    TXT = "txt"
-    XLS = "xls"

--- a/src/ynab_unlinked/entities/sabadell/sabadell.py
+++ b/src/ynab_unlinked/entities/sabadell/sabadell.py
@@ -69,18 +69,22 @@ class SabadellParser:
         from ynab_unlinked.parsers import xls
 
         # This is the row after which real transactions appear
-        row_trigger = ["FECHA", "CONCEPTO", "LOCALIDAD", "IMPORTE", "", ""]
+        row_trigger = ["FECHA", "CONCEPTO", "LOCALIDAD"]
 
         transactions = []
 
-        for entry in xls(input_file, read_after_row_like=row_trigger):
-            # If we find debing movements, stop reading
+        for entry in xls(input_file, read_after_row_like=row_trigger, allow_partial_match=True):
+            # If we find debit movements, stop reading
             # Debit movements appear at the end of the file
             if entry[0] == XLS_DEBIT_LINE:
                 break
 
-            # The order is date, payee, x, x, value
-            date, payee, amount = entry[0], entry[1], entry[4]
+            # The order is date, payee, x, x, value, EUR
+            date, payee, amount, currency = entry[0], entry[1], entry[4], entry[5]
+
+            # If currency ends in (1) is a pending transaction, skip
+            if currency.endswith("(1)"):
+                continue
 
             # If we cannot parse the date, then continue because we might be in an entry that is not a
             # transaction entry

--- a/src/ynab_unlinked/parsers/xls.py
+++ b/src/ynab_unlinked/parsers/xls.py
@@ -7,7 +7,22 @@ def xls(
     input_file: Path,
     read_after_row: int = 0,
     read_after_row_like: Sequence[str] | None = None,
+    allow_partial_match: bool = False,
 ) -> Generator[Sequence[str]]:
+    """Reads rows from an XLS file, yielding each row as a sequence of strings.
+
+    Skips a specified number of rows or until a matching row is found, then yields subsequent rows.
+    Allows for partial or full row matching to determine where to start reading.
+
+    Args:
+        input_file: The path to the XLS file to read.
+        read_after_row: The number of initial rows to skip before reading.
+        read_after_row_like: A sequence of strings to match a row after which reading should begin.
+        allow_partial_match: If True, allows partial matching of the row to start reading.
+
+    Returns:
+        Generator[Sequence[str]]: A generator yielding each row as a sequence of strings.
+    """
     import pyexcel
 
     kwargs: dict[str, Any] = {"file_name": str(input_file.absolute())}
@@ -19,7 +34,14 @@ def xls(
             continue
 
         if read_after_row_like is not None and not read:
-            if entry == read_after_row_like:
+            if allow_partial_match:
+                for after_row_idx, element in enumerate(read_after_row_like):
+                    if entry[after_row_idx] != element:
+                        break
+                else:
+                    # We have completed the loop, we are in the right place
+                    read = True
+            elif entry == read_after_row_like:
                 read = True
             continue
 


### PR DESCRIPTION
## Description
Fixes a bug in which XLS files from Sabadell could not be processed. When pending transactions were present the structure of the file was different and the anchor entry was invalid.

The Sabadell entity has also been updated to use the `extract_type` method to automatically detect the file by extension.