### PR TITLE
Release 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ To help us keep our books in order, these release notes are automatically genera
 
 <!-- towncrier release notes start -->
 
+## ynab-unlinked 0.7.0 (2026-05-01)
+
+### Bugs Squashed, Peace Restored
+* [[#10](https://github.com/AAraKKe/ynab-unlinked/issues/10)] Fix matching algorithm to properly consider imported IDs
+
+### Under the Hood Upgrades
+* [[#61](https://github.com/AAraKKe/ynab-unlinked/issues/61)] Bump platformdirs from 4.5.1 to 4.7.0
+* [[#74](https://github.com/AAraKKe/ynab-unlinked/issues/74)] Bump pypa/gh-action-pypi-publish from 1.13.0 to 1.14.0
+* [[#76](https://github.com/AAraKKe/ynab-unlinked/issues/76)] Bump softprops/action-gh-release from 2.5.0 to 3.0.0
+* [[#59](https://github.com/AAraKKe/ynab-unlinked/issues/59)] Bump textual from 7.3.0 to 7.5.0
+* [[#82](https://github.com/AAraKKe/ynab-unlinked/issues/82)] Bump textual from 7.5.0 to 8.2.5
+* [[#83](https://github.com/AAraKKe/ynab-unlinked/issues/83)] Pin all dependencies to exact versions and adapt the YNAB SDK wrapper to the 4.x `budgets` → `plans` rename
+* [[#80](https://github.com/AAraKKe/ynab-unlinked/issues/80)] Update pydantic requirement from >=2.0.0 to >=2.13.3
+
 ## ynab-unlinked 0.6.1 (2026-01-25)
 _Note_: Version 0.6.0 was skipped due to a mistake in the release process.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ To help us keep our books in order, these release notes are automatically genera
 ## ynab-unlinked 0.7.0 (2026-05-01)
 
 ### Bugs Squashed, Peace Restored
-* [[#10](https://github.com/AAraKKe/ynab-unlinked/issues/10)] Fix matching algorithm to properly consider imported IDs
+* [[#62](https://github.com/AAraKKe/ynab-unlinked/pull/62)] Fix matching algorithm to properly consider imported IDs
 
 ### Under the Hood Upgrades
 * [[#61](https://github.com/AAraKKe/ynab-unlinked/issues/61)] Bump platformdirs from 4.5.1 to 4.7.0

--- a/changelog/10.bugfix.md
+++ b/changelog/10.bugfix.md
@@ -1,1 +1,0 @@
-Fix matching algorithm to properly consider imported IDs

--- a/changelog/59.bumped.md
+++ b/changelog/59.bumped.md
@@ -1,1 +1,0 @@
-Bump textual from 7.3.0 to 7.5.0

--- a/changelog/61.bumped.md
+++ b/changelog/61.bumped.md
@@ -1,1 +1,0 @@
-Bump platformdirs from 4.5.1 to 4.7.0

--- a/changelog/74.bumped.md
+++ b/changelog/74.bumped.md
@@ -1,1 +1,0 @@
-Bump pypa/gh-action-pypi-publish from 1.13.0 to 1.14.0

--- a/changelog/76.bumped.md
+++ b/changelog/76.bumped.md
@@ -1,1 +1,0 @@
-Bump softprops/action-gh-release from 2.5.0 to 3.0.0

--- a/changelog/80.bumped.md
+++ b/changelog/80.bumped.md
@@ -1,1 +1,0 @@
-Update pydantic requirement from >=2.0.0 to >=2.13.3

--- a/changelog/82.bumped.md
+++ b/changelog/82.bumped.md
@@ -1,1 +1,0 @@
-Bump textual from 7.5.0 to 8.2.5

--- a/changelog/83.bumped.md
+++ b/changelog/83.bumped.md
@@ -1,1 +1,0 @@
-Pin all dependencies to exact versions and adapt the YNAB SDK wrapper to the 4.x `budgets` → `plans` rename

--- a/src/ynab_unlinked/__about__.py
+++ b/src/ynab_unlinked/__about__.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2025-present Juanpe Araque <juanpe@committhatline.com>
 #
 # SPDX-License-Identifier: MIT
-__version__ = "0.6.1"
+__version__ = "0.7.0"


### PR DESCRIPTION
Bumps `__about__.py` to `0.7.0` and rolls the pending towncrier fragments into `CHANGELOG.md`.

### Highlights

#### Bugs Squashed, Peace Restored
- [#10](https://github.com/AAraKKe/ynab-unlinked/issues/10) Fix matching algorithm to properly consider imported IDs

#### Under the Hood Upgrades
- [#61](https://github.com/AAraKKe/ynab-unlinked/issues/61) Bump platformdirs from 4.5.1 to 4.7.0
- [#74](https://github.com/AAraKKe/ynab-unlinked/issues/74) Bump `pypa/gh-action-pypi-publish` from 1.13.0 to 1.14.0
- [#76](https://github.com/AAraKKe/ynab-unlinked/issues/76) Bump `softprops/action-gh-release` from 2.5.0 to 3.0.0
- [#59](https://github.com/AAraKKe/ynab-unlinked/issues/59) Bump textual from 7.3.0 to 7.5.0
- [#82](https://github.com/AAraKKe/ynab-unlinked/issues/82) Bump textual from 7.5.0 to 8.2.5
- [#83](https://github.com/AAraKKe/ynab-unlinked/issues/83) Pin all dependencies to exact versions and adapt the YNAB SDK wrapper to the 4.x `budgets` → `plans` rename
- [#80](https://github.com/AAraKKe/ynab-unlinked/issues/80) Update pydantic requirement from >=2.0.0 to >=2.13.3

### Release flow

After this PR is merged, tag the merge commit with `yul-0.7.0` and push the tag — `release.yml` will validate version coherence, build, publish to PyPI, and create the GitHub release with notes extracted from `CHANGELOG.md`.