### PR TITLE
Release 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,19 +6,27 @@ To help us keep our books in order, these release notes are automatically genera
 
 <!-- towncrier release notes start -->
 
-## ynab-unlinked 0.7.0 (2026-05-01)
+## ynab-unlinked 0.8.0 (2026-05-01)
+
+### Under the Hood Upgrades
+* [[#83](https://github.com/AAraKKe/ynab-unlinked/issues/83)] Pin all dependencies to exact versions and adapt the YNAB SDK wrapper to the 4.x `budgets` → `plans` rename
+* [[#80](https://github.com/AAraKKe/ynab-unlinked/issues/80)] Update pydantic requirement from >=2.0.0 to >=2.13.3
+* [[#82](https://github.com/AAraKKe/ynab-unlinked/issues/82)] Bump textual from 7.5.0 to 8.2.5
+* [[#74](https://github.com/AAraKKe/ynab-unlinked/issues/74)] Bump pypa/gh-action-pypi-publish from 1.13.0 to 1.14.0
+* [[#76](https://github.com/AAraKKe/ynab-unlinked/issues/76)] Bump softprops/action-gh-release from 2.5.0 to 3.0.0
+
+### For the Builders: Dev Experience Upgrades
+* [[#85](https://github.com/AAraKKe/ynab-unlinked/issues/85)] Ignore `.coverage` and `.vscode/` in `git status` and skip towncrier check for `.gitignore`-only changes
+
+## ynab-unlinked 0.7.0 (2026-02-14)
+_Note_: This release was published from a commit that was never merged back into `main`. The entry below mirrors what actually shipped to PyPI.
 
 ### Bugs Squashed, Peace Restored
-* [[#62](https://github.com/AAraKKe/ynab-unlinked/pull/62)] Fix matching algorithm to properly consider imported IDs
+* [[#10](https://github.com/AAraKKe/ynab-unlinked/issues/10)] Fix matching algorithm to properly consider imported IDs
 
 ### Under the Hood Upgrades
 * [[#61](https://github.com/AAraKKe/ynab-unlinked/issues/61)] Bump platformdirs from 4.5.1 to 4.7.0
-* [[#74](https://github.com/AAraKKe/ynab-unlinked/issues/74)] Bump pypa/gh-action-pypi-publish from 1.13.0 to 1.14.0
-* [[#76](https://github.com/AAraKKe/ynab-unlinked/issues/76)] Bump softprops/action-gh-release from 2.5.0 to 3.0.0
 * [[#59](https://github.com/AAraKKe/ynab-unlinked/issues/59)] Bump textual from 7.3.0 to 7.5.0
-* [[#82](https://github.com/AAraKKe/ynab-unlinked/issues/82)] Bump textual from 7.5.0 to 8.2.5
-* [[#83](https://github.com/AAraKKe/ynab-unlinked/issues/83)] Pin all dependencies to exact versions and adapt the YNAB SDK wrapper to the 4.x `budgets` → `plans` rename
-* [[#80](https://github.com/AAraKKe/ynab-unlinked/issues/80)] Update pydantic requirement from >=2.0.0 to >=2.13.3
 
 ## ynab-unlinked 0.6.1 (2026-01-25)
 _Note_: Version 0.6.0 was skipped due to a mistake in the release process.

--- a/changelog/85.contrib.md
+++ b/changelog/85.contrib.md
@@ -1,1 +1,0 @@
-Ignore `.coverage` and `.vscode/` in `git status` and skip towncrier check for `.gitignore`-only changes

--- a/src/ynab_unlinked/__about__.py
+++ b/src/ynab_unlinked/__about__.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2025-present Juanpe Araque <juanpe@committhatline.com>
 #
 # SPDX-License-Identifier: MIT
-__version__ = "0.7.0"
+__version__ = "0.8.0"


### PR DESCRIPTION
Bumps `__about__.py` to `0.8.0`, consumes the pending towncrier fragment for #85, and rewrites the recently-merged 0.7.0 entry in `CHANGELOG.md` so the changelog matches what's actually on PyPI.

### Why two sections changed

The 0.7.0 release on PyPI was tagged on 2026-02-14 from a commit (`69159de "Bump to version 0.7.0"`) that was never merged back into `main`. As a result:

- That commit's CHANGELOG.md (the one shipped with the package) had only three entries: #10, #59, #61.
- `main`'s `changelog/` directory still held those three fragments after the release.
- When PR #84 ("Release 0.7.0") ran towncrier, it re-consumed those fragments together with five later ones (#74, #76, #80, #82, #83) and wrote a new "0.7.0" section dated 2026-05-01 that doesn't correspond to anything on PyPI.

This PR fixes that:

- The "0.7.0" section is rewritten to match what actually shipped (date 2026-02-14, only #10/#59/#61), with a `_Note_` explaining the orphan-tag situation.
- The five entries that didn't ship in 0.7.0 — plus the new #85 — are moved into a fresh `## ynab-unlinked 0.8.0 (2026-05-01)` section, in the canonical towncrier section order (`bumped` before `contrib`).

### Release flow

After this PR is merged, tag the merge commit with `yul-0.8.0` and push the tag. `release.yml` will validate that `hatch version` is `0.8.0` and that the section header exists, then build, publish to PyPI, and create the GitHub Release with notes extracted from the new section.