### PR TITLE
Add privacy notice and yul config reset

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,103 @@
+# Privacy Notice — YNAB Unlinked
+
+_Last updated: 2026-05-01_
+
+YNAB Unlinked runs entirely on your computer. The only network calls it makes are to YNAB's API at `https://api.ynab.com`, authenticated with the YNAB Personal Access Token you provide. Nothing is sent to any third party. There is no telemetry.
+
+## Scope
+
+This notice applies to the `ynab-unlinked` command-line tool (`yul`) distributed via PyPI.
+
+## What this tool reads from YNAB
+
+When you run a command, YNAB Unlinked may read the following from your YNAB account, scoped to the budget you selected during `yul setup`:
+
+- Budgets (list and details)
+- Accounts
+- Transactions
+- Payees
+
+It also writes data back to YNAB on your behalf:
+
+- Creates new transactions in the account you point it at.
+- Updates existing transactions during reconciliation (cleared/reconciled state).
+
+## What leaves your computer
+
+Only HTTPS requests to `https://api.ynab.com`, made by the official `ynab` Python SDK and authenticated with your Personal Access Token.
+
+There is no analytics, telemetry, crash reporting, or any other outbound traffic.
+
+## Bank export files
+
+`yul load` reads the bank export files (CSV, XLSX, PDF, …) you give it as input. These files are parsed locally, used to build the list of transactions, and never copied or transmitted outside the YNAB API calls described above. The tool does not retain a copy of them.
+
+## What is stored locally
+
+YNAB Unlinked stores a single JSON configuration file containing:
+
+- Your YNAB Personal Access Token
+- Selected budget metadata: id, name, date format, currency format
+- Per-entity checkpoints (last processed date and transaction hash)
+- Payee rules
+- The date of your last reconciliation
+
+The file is **plaintext** and **not encrypted**. Where it lives depends on your operating system (resolved via [`platformdirs`](https://pypi.org/project/platformdirs/)):
+
+| OS      | Path                                                                |
+| ------- | ------------------------------------------------------------------- |
+| macOS   | `~/Library/Application Support/ynab-unlinked/config.json`           |
+| Linux   | `$XDG_CONFIG_HOME/ynab-unlinked/config.json` (typically `~/.config/ynab-unlinked/config.json`) |
+| Windows | `%APPDATA%\committhatline\ynab-unlinked\config.json`                |
+
+If you have an old configuration created before version `0.7.0`, a legacy file may also exist at `~/.config/ynab_unlinked/config.json` (note the underscore).
+
+You can run `yul privacy` at any time to print the resolved path on your machine.
+
+### Security caveat
+
+Because the token is stored in plaintext, anyone with read access to the file above can use it as if they were you. We strongly recommend:
+
+- Use full-disk encryption (FileVault, LUKS, BitLocker).
+- Restrict file permissions to your user (`chmod 600` on macOS/Linux).
+- If you suspect the file has leaked, **revoke the token immediately** in YNAB → Account Settings → Developer Settings, and generate a new one.
+
+## Dependencies that touch your data
+
+These dependencies are loaded by the tool and may read or transmit data on your behalf:
+
+- [`ynab`](https://pypi.org/project/ynab/) — the official YNAB SDK. Talks to `api.ynab.com` only.
+- [`pdfplumber`](https://pypi.org/project/pdfplumber/), [`pyexcel`](https://pypi.org/project/pyexcel/), [`pyexcel-xls`](https://pypi.org/project/pyexcel-xls/), [`pyexcel-xlsx`](https://pypi.org/project/pyexcel-xlsx/) — local parsers for the import files you provide. They do not send any data anywhere.
+- [`pydantic`](https://pypi.org/project/pydantic/), [`platformdirs`](https://pypi.org/project/platformdirs/), [`typer`](https://pypi.org/project/typer/), [`rich`](https://pypi.org/project/rich/), [`rapidfuzz`](https://pypi.org/project/rapidfuzz/), [`unidecode`](https://pypi.org/project/Unidecode/), [`html-text`](https://pypi.org/project/html-text/), [`textual`](https://pypi.org/project/textual/) — local utility libraries; none of them phone home.
+
+## Telemetry
+
+None. The tool does not collect or transmit any usage data, analytics, or crash reports.
+
+## Third parties
+
+The tool does not share any data with any third party. The only external service it talks to is YNAB itself.
+
+## Deleting your data
+
+To remove everything YNAB Unlinked has stored on your machine:
+
+```sh
+yul config reset
+```
+
+This deletes the configuration directory listed above, including your API key, budget, payee rules, and entity checkpoints. Pass `--yes` (or `-y`) to skip the confirmation prompt.
+
+After deleting the local data, you may also want to **revoke the Personal Access Token** in YNAB → Account Settings → Developer Settings to ensure the token cannot be reused.
+
+## Changes to this notice
+
+Material changes to this notice will be announced in `CHANGELOG.md` and the _Last updated_ date at the top of this file will be bumped.
+
+## Disclaimer
+
+We are not affiliated, associated, or in any way officially connected with YNAB or any of its subsidiaries or affiliates. The names "YNAB" and "You Need A Budget" are trademarks of their respective owners.
+
+## Contact
+
+Questions, concerns, or requests can be filed at the [issue tracker](https://github.com/AAraKKe/ynab-unlinked/issues).

--- a/README.md
+++ b/README.md
@@ -7,6 +7,22 @@ Want to know more? Check out our [wiki](https://github.com/AAraKKe/ynab-unlinked
 > [!IMPORTANT]
 > This project just started and is open to contributions!
 
+## Privacy
+
+YNAB Unlinked runs entirely on your computer and only talks to YNAB's API. There is no telemetry and no data is shared with any third party. Your YNAB Personal Access Token is stored locally, in plaintext, in the standard config directory for your OS.
+
+Run `yul privacy` to see what is stored on your machine and where, or read the full [privacy notice](./PRIVACY.md).
+
+To wipe all locally stored data, including your API key, run:
+
+```sh
+yul config reset
+```
+
+## Disclaimer
+
+We are not affiliated, associated, or in any way officially connected with YNAB or any of its subsidiaries or affiliates. The names "YNAB" and "You Need A Budget" are trademarks of their respective owners.
+
 ## License
 
 `ynab-unlinked` is distributed under the terms of the [MIT](https://spdx.org/licenses/MIT.html) license.

--- a/changelog/+privacy.added.md
+++ b/changelog/+privacy.added.md
@@ -1,0 +1,1 @@
+New `yul privacy` command that prints what data YNAB Unlinked stores on your computer, where it lives, and how to delete it. New `yul config reset` command that wipes all locally stored data, including your YNAB API key. Pass `--yes` to skip the confirmation prompt.

--- a/changelog/+privacy.doc.md
+++ b/changelog/+privacy.doc.md
@@ -1,0 +1,1 @@
+Added a [privacy notice](https://github.com/AAraKKe/ynab-unlinked/blob/main/PRIVACY.md) describing what data YNAB Unlinked reads from YNAB, what stays on your machine and where, and how to delete it. Added the corresponding "Privacy" and "Disclaimer" sections to the README.

--- a/changelog/+privacy.improved.md
+++ b/changelog/+privacy.improved.md
@@ -1,0 +1,1 @@
+`yul setup` and `yul config set api_key` now show a short notice explaining where your YNAB API key will be stored before asking for it.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,9 +45,10 @@ dependencies = [
 yul = "ynab_unlinked.main:main"
 
 [project.urls]
-Documentation = "https://github.com/Juanpe Araque/ynab-unlinked#readme"
-Issues = "https://github.com/Juanpe Araque/ynab-unlinked/issues"
-Source = "https://github.com/Juanpe Araque/ynab-unlinked"
+Documentation = "https://github.com/AAraKKe/ynab-unlinked#readme"
+Issues = "https://github.com/AAraKKe/ynab-unlinked/issues"
+Source = "https://github.com/AAraKKe/ynab-unlinked"
+Privacy = "https://github.com/AAraKKe/ynab-unlinked/blob/main/PRIVACY.md"
 
 [tool.hatch.version]
 path = "src/ynab_unlinked/__about__.py"

--- a/src/ynab_unlinked/commands/__init__.py
+++ b/src/ynab_unlinked/commands/__init__.py
@@ -1,5 +1,6 @@
 from .config import config_app
 from .load import load
+from .privacy import privacy_command
 from .reconcile import reconcile
 
-__all__ = ["config_app", "load", "reconcile"]
+__all__ = ["config_app", "load", "privacy_command", "reconcile"]

--- a/src/ynab_unlinked/commands/config.py
+++ b/src/ynab_unlinked/commands/config.py
@@ -1,11 +1,15 @@
+import shutil
 from enum import StrEnum
+from pathlib import Path
 from typing import Annotated, assert_never
 
 import typer
 
 from ynab_unlinked.config import ConfigV2
-from ynab_unlinked.context_object import YnabUnlinkedContext
-from ynab_unlinked.display import console, success
+from ynab_unlinked.config.paths import config_path, v1_config_path
+from ynab_unlinked.display import bullet_list, confirm, console, info, success, warning
+from ynab_unlinked.privacy import privacy_notice
+from ynab_unlinked.setup import ensure_config
 from ynab_unlinked.utils import prompt_for_api_key, prompt_for_budget
 
 
@@ -23,11 +27,12 @@ def set_command(
     key: Annotated[ValidKeys, typer.Argument(help="The config key to set", show_default=False)],
 ):
     """Set configuration options"""
-    ctx: YnabUnlinkedContext = context.obj
+    ctx = ensure_config(context)
     config: ConfigV2 = ctx.config
 
     match key:
         case ValidKeys.API_KEY:
+            privacy_notice()
             api_key = prompt_for_api_key()
             config.api_key = api_key
             config.save()
@@ -43,6 +48,44 @@ def set_command(
 
 @config_app.command(name="show")
 def show(context: typer.Context):
-    ctx: YnabUnlinkedContext = context.obj
+    ctx = ensure_config(context)
     config: ConfigV2 = ctx.config
     console().print(config.model_dump_json(indent=2))
+
+
+@config_app.command(name="reset")
+def reset_command(
+    yes: Annotated[
+        bool,
+        typer.Option("--yes", "-y", help="Skip the confirmation prompt."),
+    ] = False,
+):
+    """Delete all locally stored YNAB Unlinked data, including your YNAB API key."""
+    paths_to_remove: list[Path] = []
+
+    v2_dir = config_path().parent
+    if v2_dir.is_dir():
+        paths_to_remove.append(v2_dir)
+
+    v1_path = v1_config_path()
+    if v1_path.is_file() and v1_path.parent not in paths_to_remove:
+        paths_to_remove.append(v1_path.parent)
+
+    if not paths_to_remove:
+        info("No YNAB Unlinked data was found on this machine. Nothing to delete.")
+        return
+
+    info("The following directories will be permanently deleted:")
+    info(bullet_list(str(p) for p in paths_to_remove))
+    warning(
+        "This will remove your YNAB API key, selected budget, payee rules, and entity checkpoints."
+    )
+
+    if not yes and not confirm("Are you sure you want to continue?", default=False):
+        info("Aborted. Nothing was deleted.")
+        return
+
+    for path in paths_to_remove:
+        shutil.rmtree(path)
+
+    success("🧹 All locally stored YNAB Unlinked data has been deleted.")

--- a/src/ynab_unlinked/commands/load.py
+++ b/src/ynab_unlinked/commands/load.py
@@ -5,7 +5,7 @@ from typing import Annotated
 import typer
 
 from ynab_unlinked import entities
-from ynab_unlinked.context_object import YnabUnlinkedContext
+from ynab_unlinked.setup import ensure_config
 
 load = typer.Typer(
     help="Load transactions from a bank statement into your YNAB account.",
@@ -46,7 +46,7 @@ def load_callback(
         ),
     ] = 15,
 ):
-    obj: YnabUnlinkedContext = context.obj
+    obj = ensure_config(context)
 
     obj.show = show
     obj.reconcile = reconcile

--- a/src/ynab_unlinked/commands/privacy.py
+++ b/src/ynab_unlinked/commands/privacy.py
@@ -1,0 +1,6 @@
+from ynab_unlinked.privacy import privacy_summary
+
+
+def privacy_command():
+    """Show what data YNAB Unlinked stores on your computer and where."""
+    privacy_summary()

--- a/src/ynab_unlinked/commands/reconcile.py
+++ b/src/ynab_unlinked/commands/reconcile.py
@@ -9,8 +9,8 @@ from ynab_unlinked.choices import Choice
 from ynab_unlinked.commands.apps.reconcile import Reconcile
 from ynab_unlinked.config import ConfigV2
 from ynab_unlinked.config.constants import TRANSACTION_GRACE_PERIOD_DAYS
-from ynab_unlinked.context_object import YnabUnlinkedContext
 from ynab_unlinked.display import process
+from ynab_unlinked.setup import ensure_config
 from ynab_unlinked.ynab_api import Client
 
 
@@ -69,7 +69,7 @@ def reconcile(
 ):
     """Help reconciling your accounts in one go"""
 
-    ctx: YnabUnlinkedContext = context.obj
+    ctx = ensure_config(context)
     config: ConfigV2 = ctx.config
 
     budget_id = config.budget.id

--- a/src/ynab_unlinked/main.py
+++ b/src/ynab_unlinked/main.py
@@ -1,18 +1,15 @@
-from typing import Final, cast
+from typing import Final
 
 import typer
 
 from ynab_unlinked import app
-from ynab_unlinked.commands import config_app, load
-from ynab_unlinked.config import Config, ConfigV1, ConfigV2, get_config
-from ynab_unlinked.config.core import ConfigError
-from ynab_unlinked.context_object import YnabUnlinkedContext
-from ynab_unlinked.display import bold, success
-from ynab_unlinked.formatter import Formatter
-from ynab_unlinked.utils import prompt_for_api_key, prompt_for_budget
+from ynab_unlinked.commands import config_app, load, privacy_command
+from ynab_unlinked.config import Config, ConfigV1, ConfigV2
+from ynab_unlinked.setup import load_context, run_setup
 
 app.add_typer(load, name="load")
 app.add_typer(config_app, name="config")
+app.command(name="privacy")(privacy_command)
 
 VERSION_MAPPING: Final[dict[str, type[Config]]] = {
     "V1": ConfigV1,
@@ -23,13 +20,7 @@ VERSION_MAPPING: Final[dict[str, type[Config]]] = {
 @app.command(name="setup")
 def setup_command():
     """Setup YNAB Unlinked"""
-    bold("Welcome to ynab-unlinked! Lets setup your connection")
-    api_key = prompt_for_api_key()
-    budget = prompt_for_budget(api_key)
-    config = ConfigV2(api_key=api_key, budget=budget)
-    config.save()
-
-    success("All done!")
+    run_setup()
 
 
 @app.callback(no_args_is_help=True)
@@ -41,28 +32,11 @@ def cli(context: typer.Context):
     The first time the command is run you will be asked some questions to setup your YNAB connection. After that,
     transaction processing won't require any input unless there are some actions to take for specific transactions.
     """
-
-    if context.invoked_subcommand == "setup":
-        # If we are running setup there is nothing to do here
-        return
-
-    # Load the proper config or run setup to create it
-    config = get_config()
-    if config is None:
-        setup_command()
-        config = get_config()
-
-    if config is None:
-        raise ConfigError("Unexpected error: config could not be loaded")
-
-    context.obj = YnabUnlinkedContext(
-        config=cast(ConfigV2, config),
-        extras=None,
-        formatter=Formatter(
-            date_format=config.budget.date_format,
-            currency_format=config.budget.currency_format,
-        ),
-    )
+    # Load the persisted config when one exists. Commands that need a
+    # config call ``ensure_config`` to either pick it up here or prompt
+    # setup. Commands that don't (``setup``, ``privacy``, ``config reset``)
+    # simply ignore ``context.obj``.
+    context.obj = load_context()
 
 
 def main():

--- a/src/ynab_unlinked/privacy.py
+++ b/src/ynab_unlinked/privacy.py
@@ -1,0 +1,71 @@
+"""Privacy notice text and helpers shared across commands.
+
+Keep the wording here in sync with the PRIVACY.md document at the repo root.
+"""
+
+from __future__ import annotations
+
+from ynab_unlinked.config.paths import config_path
+from ynab_unlinked.display import bullet_list, console, info, warning
+
+PRIVACY_DOC_URL = "https://github.com/AAraKKe/ynab-unlinked/blob/main/PRIVACY.md"
+
+
+def storage_path() -> str:
+    return str(config_path().parent)
+
+
+def privacy_notice() -> None:
+    """Short notice shown before asking the user for their YNAB API key."""
+    info(
+        "[bold]Heads up:[/bold] YNAB Unlinked stores your API key locally on this "
+        f"machine, in plaintext, at:\n  [cyan]{storage_path()}[/cyan]"
+    )
+    info(
+        "All data stays on your computer — the only network calls go to api.ynab.com. "
+        f"Full privacy notice: [link={PRIVACY_DOC_URL}]{PRIVACY_DOC_URL}[/link]"
+    )
+
+
+def privacy_summary() -> None:
+    """Long-form summary printed by `yul privacy`."""
+    console().rule("[bold]YNAB Unlinked — Privacy Summary[/bold]")
+    info(
+        "YNAB Unlinked runs entirely on your computer. The only network calls it "
+        "makes are to YNAB's API at https://api.ynab.com. Nothing is sent to any "
+        "third party. There is no telemetry."
+    )
+
+    info("\n[bold]What is stored locally[/bold]")
+    info(
+        bullet_list(
+            [
+                "Your YNAB Personal Access Token (plaintext)",
+                "Selected budget metadata (id, name, date and currency formats)",
+                "Per-entity checkpoints (last processed date and transaction hash)",
+                "Payee rules",
+                "Last reconciliation date",
+            ]
+        )
+    )
+
+    info(f"\n[bold]Where[/bold]: [cyan]{storage_path()}[/cyan]")
+
+    info("\n[bold]Deleting your data[/bold]")
+    info(
+        "Run [cyan]yul config reset[/cyan] to wipe all locally stored data, including "
+        "your API key. Then revoke the token in YNAB → Account Settings → Developer "
+        "Settings."
+    )
+
+    warning(
+        "\nYour API key is stored unencrypted. Anyone with read access to the file "
+        "above can use it as if they were you. Use full-disk encryption and "
+        "restrict file permissions accordingly."
+    )
+
+    info(
+        f"\nFull privacy notice: [link={PRIVACY_DOC_URL}]{PRIVACY_DOC_URL}[/link]\n"
+        "We are not affiliated, associated, or in any way officially connected with "
+        "YNAB or any of its subsidiaries or affiliates."
+    )

--- a/src/ynab_unlinked/setup.py
+++ b/src/ynab_unlinked/setup.py
@@ -1,0 +1,78 @@
+"""Interactive setup flow and the ``ensure_config`` helper.
+
+Lives in its own module so commands that need it can import without
+pulling ``main`` (avoids import cycles).
+"""
+
+from __future__ import annotations
+
+from typing import cast
+
+import typer
+
+from ynab_unlinked.config import ConfigV2, get_config
+from ynab_unlinked.config.core import ConfigError
+from ynab_unlinked.context_object import YnabUnlinkedContext
+from ynab_unlinked.display import bold, success
+from ynab_unlinked.formatter import Formatter
+from ynab_unlinked.privacy import privacy_notice
+from ynab_unlinked.utils import prompt_for_api_key, prompt_for_budget
+
+
+def run_setup() -> ConfigV2:
+    """Run the interactive setup flow and persist a fresh config."""
+    bold("Welcome to ynab-unlinked! Lets setup your connection")
+    privacy_notice()
+    api_key = prompt_for_api_key()
+    budget = prompt_for_budget(api_key)
+    config = ConfigV2(api_key=api_key, budget=budget)
+    config.save()
+    success("All done!")
+    return config
+
+
+def _build_context(config: ConfigV2) -> YnabUnlinkedContext:
+    return YnabUnlinkedContext(
+        config=config,
+        extras=None,
+        formatter=Formatter(
+            date_format=config.budget.date_format,
+            currency_format=config.budget.currency_format,
+        ),
+    )
+
+
+def load_context() -> YnabUnlinkedContext | None:
+    """Try to load the persisted config and wrap it in a YnabUnlinkedContext.
+
+    Returns ``None`` if no config exists or the file cannot be loaded
+    (e.g. corrupted). The caller decides whether to prompt setup or
+    bail out.
+    """
+    try:
+        config = get_config()
+    except Exception:
+        return None
+
+    if config is None:
+        return None
+
+    return _build_context(cast(ConfigV2, config))
+
+
+def ensure_config(context: typer.Context) -> YnabUnlinkedContext:
+    """Make sure ``context.obj`` has a valid config, prompting setup if missing."""
+    obj: YnabUnlinkedContext | None = context.obj
+    if obj is not None:
+        return obj
+
+    config = get_config()
+    if config is None:
+        config = run_setup()
+
+    if config is None:
+        raise ConfigError("Unexpected error: config could not be loaded after setup")
+
+    obj = _build_context(cast(ConfigV2, config))
+    context.obj = obj
+    return obj

--- a/tests/commands/test_config_reset.py
+++ b/tests/commands/test_config_reset.py
@@ -1,0 +1,76 @@
+from pathlib import Path
+
+from pytest_mock import MockerFixture
+from typer.testing import CliRunner as TyperRunner
+
+from ynab_unlinked.main import app
+
+
+def _patch_paths(mocker: MockerFixture, v2_config: Path, v1_config: Path) -> None:
+    mocker.patch("ynab_unlinked.commands.config.config_path", return_value=v2_config)
+    mocker.patch("ynab_unlinked.commands.config.v1_config_path", return_value=v1_config)
+    mocker.patch("ynab_unlinked.privacy.config_path", return_value=v2_config)
+    mocker.patch("ynab_unlinked.config.core.config_path", return_value=v2_config)
+
+
+def test_reset_deletes_v2_directory_with_yes_flag(tmp_path: Path, mocker: MockerFixture) -> None:
+    v2_dir = tmp_path / "ynab-unlinked"
+    v2_dir.mkdir()
+    v2_config = v2_dir / "config.json"
+    v2_config.write_text('{"version": "V2"}')
+    v1_config = tmp_path / "missing" / "config.json"
+
+    _patch_paths(mocker, v2_config, v1_config)
+
+    result = TyperRunner().invoke(app, ["config", "reset", "--yes"])
+
+    assert result.exit_code == 0, result.output
+    assert not v2_dir.exists()
+    assert "deleted" in result.output.lower()
+
+
+def test_reset_aborts_when_user_declines(tmp_path: Path, mocker: MockerFixture) -> None:
+    v2_dir = tmp_path / "ynab-unlinked"
+    v2_dir.mkdir()
+    v2_config = v2_dir / "config.json"
+    v2_config.write_text('{"version": "V2"}')
+    v1_config = tmp_path / "missing" / "config.json"
+
+    _patch_paths(mocker, v2_config, v1_config)
+
+    result = TyperRunner().invoke(app, ["config", "reset"], input="n\n")
+
+    assert result.exit_code == 0, result.output
+    assert v2_dir.exists()
+    assert "Aborted" in result.output
+
+
+def test_reset_when_nothing_exists_is_a_no_op(tmp_path: Path, mocker: MockerFixture) -> None:
+    v2_config = tmp_path / "missing-v2" / "config.json"
+    v1_config = tmp_path / "missing-v1" / "config.json"
+    _patch_paths(mocker, v2_config, v1_config)
+
+    result = TyperRunner().invoke(app, ["config", "reset", "--yes"])
+
+    assert result.exit_code == 0, result.output
+    assert "Nothing to delete" in result.output
+
+
+def test_reset_also_removes_legacy_v1_directory(tmp_path: Path, mocker: MockerFixture) -> None:
+    v2_dir = tmp_path / "ynab-unlinked"
+    v2_dir.mkdir()
+    v2_config = v2_dir / "config.json"
+    v2_config.write_text('{"version": "V2"}')
+
+    v1_dir = tmp_path / "ynab_unlinked"
+    v1_dir.mkdir()
+    v1_config = v1_dir / "config.json"
+    v1_config.write_text("{}")
+
+    _patch_paths(mocker, v2_config, v1_config)
+
+    result = TyperRunner().invoke(app, ["config", "reset", "--yes"])
+
+    assert result.exit_code == 0, result.output
+    assert not v2_dir.exists()
+    assert not v1_dir.exists()

--- a/tests/commands/test_privacy.py
+++ b/tests/commands/test_privacy.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+
+from pytest_mock import MockerFixture
+from typer.testing import CliRunner as TyperRunner
+
+from ynab_unlinked.main import app
+
+# Wide enough that absolute test paths don't get wrapped across lines by Rich.
+WIDE_TERMINAL = {"COLUMNS": "1000"}
+
+
+def _flatten(text: str) -> str:
+    """Collapse the line breaks Rich introduces when wrapping output."""
+    return text.replace("\n", "")
+
+
+def test_privacy_command_prints_resolved_storage_path(
+    tmp_path: Path, mocker: MockerFixture
+) -> None:
+    config_file = tmp_path / "ynab-unlinked" / "config.json"
+    mocker.patch("ynab_unlinked.privacy.config_path", return_value=config_file)
+
+    result = TyperRunner().invoke(app, ["privacy"], env=WIDE_TERMINAL)
+
+    assert result.exit_code == 0, result.output
+    output = _flatten(result.output)
+    assert str(config_file.parent) in output
+    assert "yul config reset" in output
+    assert "PRIVACY.md" in output
+    assert "not affiliated" in output.lower()
+
+
+def test_privacy_command_runs_without_a_config_present(
+    tmp_path: Path, mocker: MockerFixture
+) -> None:
+    """`yul privacy` must work even when no config has been created yet."""
+    missing_config = tmp_path / "no-such-dir" / "config.json"
+    mocker.patch("ynab_unlinked.privacy.config_path", return_value=missing_config)
+    mocker.patch("ynab_unlinked.config.core.config_path", return_value=missing_config)
+
+    result = TyperRunner().invoke(app, ["privacy"], env=WIDE_TERMINAL)
+
+    assert result.exit_code == 0, result.output
+    assert str(missing_config.parent) in _flatten(result.output)


### PR DESCRIPTION
## Summary

- Adds a `PRIVACY.md` describing what data the tool reads from YNAB, what stays on the user's machine and where, and how to wipe it.
- New `yul privacy` command that prints a runtime summary and the resolved local config path.
- New `yul config reset` command that deletes all locally stored data (token, budget, payee rules, entity checkpoints), with a confirmation prompt and a `--yes` flag.
- `yul setup` and `yul config set api_key` now show a short heads-up about local plaintext storage before asking for the YNAB API key.
- Adds the YNAB-not-affiliated disclaimer + a "Privacy" section to the README, and fixes the broken project URLs in `pyproject.toml`.

## Notes

- Pulled the setup flow and config loading into a new `setup.py` so `yul privacy` and `yul config reset` work even when the config file is missing or corrupted. Commands that need a config now call `ensure_config(context)`, which behaves exactly like the previous auto-setup-on-first-run flow for `load`, `reconcile`, `config show` and `config set`.
- No new runtime dependencies. No telemetry was added or changed (there is none).

## Test plan

- [x] `hatch run dev:check` (ruff + format + pyright) clean
- [x] `hatch run dev:cov` — 94 passed
- [x] Smoke `yul --help`, `yul privacy`, `yul config --help`
- [ ] Reviewer: try `yul config reset` on a real config to confirm the directory is deleted as expected