### PR TITLE
Release 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ To help us keep our books in order, these release notes are automatically genera
 
 <!-- towncrier release notes start -->
 
+## ynab-unlinked 0.9.0 (2026-05-01)
+
+### Fresh Out of the Feature Oven
+* New `yul privacy` command that prints what data YNAB Unlinked stores on your computer, where it lives, and how to delete it. New `yul config reset` command that wipes all locally stored data, including your YNAB API key. Pass `--yes` to skip the confirmation prompt.
+
+### Polished Until It Shines
+* `yul setup` and `yul config set api_key` now show a short notice explaining where your YNAB API key will be stored before asking for it.
+
+### Read All About It! (Docs Updates)
+* Added a [privacy notice](https://github.com/AAraKKe/ynab-unlinked/blob/main/PRIVACY.md) describing what data YNAB Unlinked reads from YNAB, what stays on your machine and where, and how to delete it. Added the corresponding "Privacy" and "Disclaimer" sections to the README.
+
 ## ynab-unlinked 0.8.0 (2026-05-01)
 
 ### Under the Hood Upgrades

--- a/changelog/+privacy.added.md
+++ b/changelog/+privacy.added.md
@@ -1,1 +1,0 @@
-New `yul privacy` command that prints what data YNAB Unlinked stores on your computer, where it lives, and how to delete it. New `yul config reset` command that wipes all locally stored data, including your YNAB API key. Pass `--yes` to skip the confirmation prompt.

--- a/changelog/+privacy.doc.md
+++ b/changelog/+privacy.doc.md
@@ -1,1 +1,0 @@
-Added a [privacy notice](https://github.com/AAraKKe/ynab-unlinked/blob/main/PRIVACY.md) describing what data YNAB Unlinked reads from YNAB, what stays on your machine and where, and how to delete it. Added the corresponding "Privacy" and "Disclaimer" sections to the README.

--- a/changelog/+privacy.improved.md
+++ b/changelog/+privacy.improved.md
@@ -1,1 +1,0 @@
-`yul setup` and `yul config set api_key` now show a short notice explaining where your YNAB API key will be stored before asking for it.

--- a/src/ynab_unlinked/__about__.py
+++ b/src/ynab_unlinked/__about__.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2025-present Juanpe Araque <juanpe@committhatline.com>
 #
 # SPDX-License-Identifier: MIT
-__version__ = "0.8.0"
+__version__ = "0.9.0"


### PR DESCRIPTION
Bumps `__about__.py` to `0.9.0` and consumes the pending towncrier fragments from #87 into `CHANGELOG.md`.

### What's in 0.9.0

- New `yul privacy` command and `yul config reset` command (#87).
- `yul setup` and `yul config set api_key` now show a short heads-up about local plaintext storage before asking for the YNAB API key (#87).
- Added `PRIVACY.md` and the corresponding sections to the README (#87).

### Release flow

After this PR is merged, tag the merge commit with `yul-0.9.0` and push the tag. `release.yml` will validate that `hatch version` is `0.9.0` and that the section header exists, then build, publish to PyPI, and create the GitHub Release with notes extracted from the new section.